### PR TITLE
Enhancement: Added functionality to read  name and url from config file

### DIFF
--- a/server/api/task/task.config.json
+++ b/server/api/task/task.config.json
@@ -1,0 +1,22 @@
+{
+    "workstreams": 
+            [
+                {
+                    "name" :"workstream1",
+                    "url" : "http://localhost:9000/files/file1.json"
+                },
+                {
+                    "name" :"workstream2",
+                    "url" : "http://localhost:9000/files/file2.json"
+                },
+                {
+                    "name" :"workstream3",
+                    "url" : "http://localhost:9000/files/file3.json"
+                },
+                {
+                    "name" :"workstream4",
+                    "url" : "http://localhost:9000/files/file4.json"
+                }
+                
+            ]
+}

--- a/server/api/task/task.controller.js
+++ b/server/api/task/task.controller.js
@@ -5,9 +5,11 @@ var CombinedStream = require('combined-stream');
 var request = require("request");
 var accum = require('accum');
 var q = require('q');
-
+var fs = require('fs');
 exports.index = function (req, res) {
     console.log('index');
+    //read config file
+    var config = require('./task.config');
     var combinedStream = CombinedStream.create();
 
 
@@ -18,19 +20,23 @@ exports.index = function (req, res) {
     //And promises can be chained so that after each callback is done, the data can be
     //validated and send to combined-stream. Once that is done next URL can be called and
     //the process can be repeated till all the urls are called.
-    //ToDo: make urls and project names configurable
+    
+    //The project name and the corresponding url is read from task.config.json. The name
+    //needs to be read from config file because if the retrieve JSON is invalid, reading the
+    //workstream name from it may not be correct or in readable form. 
+    //Note: workstram name is only used for logging when the received JSON is invalid.
     combinedStream.append('[');
-    retrieveData('http://localhost:9000/files/file1.json').then(function (data) {
-        validateAndAppend(data, combinedStream, ',', 'workstream1');
-        return retrieveData('http://localhost:9000/files/file2.json');
+    retrieveData(config.workstreams[0].url).then(function (data) {
+        validateAndAppend(data, combinedStream, ',', config.workstreams[0].name);
+        return retrieveData(config.workstreams[1].url);
     }).then(function (data) {
-        validateAndAppend(data, combinedStream, ',', 'workstream2');
-        return retrieveData('http://localhost:9000/files/file3.json');
+        validateAndAppend(data, combinedStream, ',', config.workstreams[1].name);
+        return retrieveData(config.workstreams[2].url);
     }).then(function (data) {
-        validateAndAppend(data, combinedStream, ',', 'workstream3');
-        return retrieveData('http://localhost:9000/files/file4.json');
+        validateAndAppend(data, combinedStream, ',', config.workstreams[2].name);
+        return retrieveData(config.workstreams[3].url);
     }).then(function (data) {
-        validateAndAppend(data, combinedStream, ']', 'workstream4');
+        validateAndAppend(data, combinedStream, ']', config.workstreams[3].name);
 
         combinedStream.pipe(accum.string({encoding: 'utf8'}, function (alldata) {
             return res.json(200, JSON.parse(alldata));
@@ -62,6 +68,10 @@ function retrieveData(url) {
 //this function validates the json data and appends it to existing data
 //if json is invalid, the error message is logged on the console along with
 //the work stream name
+//data - JSON string to be validated
+//combinedStream - CombinedStream instance
+//appendChar- the character to be used when valid JSON is appended to existing data
+//workStreamName - name of the workstream whose JSON data is being validated. Only used when JSON is invalid, to log the name 
 function validateAndAppend(data, combinedStream, appendChar, workStreamName) {
     if (isValidJson(data)) {
         combinedStream.append(data);
@@ -76,7 +86,7 @@ function validateAndAppend(data, combinedStream, appendChar, workStreamName) {
         } else {
             combinedStream.append('{ },');
         }
-        console.log('recieved invalid json for project [' + workStreamName + ']');
+        console.log('recieved invalid json for workstream [' + workStreamName + ']');
     }
 }
 


### PR DESCRIPTION
Added config file and funtionality to read workstream name url from it. The project name and the corresponding url is read from task.config.json. The name needs to be read from config file because if the retrieve JSON is invalid, reading the workstream name from it may not be correct or in readable form. 
Note: workstram name is only used for logging when the received JSON is invalid.